### PR TITLE
Make fixtures session-scoped

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,47 +20,48 @@ EXPECTED_COLORIZED_PC_PATH = EXPECTED_FILE_DIR.joinpath('expected_colorized.las'
 
 # Convenience fixtures providing laspy.lasdata.LasData representation for the
 # input, actual output, and expected output
-@pytest.fixture
+@pytest.fixture(scope='session')
 def input_lasdata(input_path):
     lasdata = laspy.read(input_path)
     return lasdata
 
-@pytest.fixture
+@pytest.fixture(scope='session')
 def output_lasdata(output_path):
     lasdata = laspy.read(output_path)
     return lasdata
 
-@pytest.fixture
+@pytest.fixture(scope='session')
 def expected_lasdata():
     lasdata = laspy.read(EXPECTED_COLORIZED_PC_PATH)
     return lasdata
 
 # Fixtures to exercise the different combinations of input arguments
-@pytest.fixture(params=[None, COLORIZATION_RASTER_PATH])
+@pytest.fixture(scope='session', params=[None, COLORIZATION_RASTER_PATH])
 def colorization_raster(request):
     return request.param
 
-@pytest.fixture(params=[False, True])
+@pytest.fixture(scope='session', params=[False, True])
 def retain_extra_dims(request):
     return request.param
 
-@pytest.fixture(params=[False, True])
+@pytest.fixture(scope='session', params=[False, True])
 def write_compressed(request):
     return request.param
 
 # The input pointcloud file, with the various formats
-@pytest.fixture(params=INPUT_PC_PATHS)
+@pytest.fixture(scope='session', params=INPUT_PC_PATHS)
 def input_path(request):
     return request.param
 
 # The availability of the output_path fixture implies that the file has been written
-@pytest.fixture
-def output_path(input_path, colorization_raster, retain_extra_dims, write_compressed, tmp_path):
+@pytest.fixture(scope='session')
+def output_path(input_path, colorization_raster, retain_extra_dims, write_compressed, tmp_path_factory):
     if write_compressed:
         output_extension = 'laz'
     else:
         output_extension = 'las'
-    _output_path = tmp_path.joinpath(f'output.{output_extension}')
+    tmp_output_dir = tmp_path_factory.mktemp('tmp_output_dir')
+    _output_path = tmp_output_dir.joinpath(f'output.{output_extension}')
 
     call_args = [
         'dvrwarp',
@@ -78,6 +79,7 @@ def output_path(input_path, colorization_raster, retain_extra_dims, write_compre
     # Print resulting argument list for easier debugging (will be captured by
     # pytest unless it is called with the -s flag)
     print('call:\n{}'.format(' '.join(call_args)))
+
     subprocess.check_call(call_args)
 
     return _output_path


### PR DESCRIPTION
Greatly improves test performance since output files are reused where possible.